### PR TITLE
changed frontend+nodejs.md example: Carol can change the flowRate.

### DIFF
--- a/protocol-tutorials/frontend-+-nodejs.md
+++ b/protocol-tutorials/frontend-+-nodejs.md
@@ -138,12 +138,12 @@ console.log(details);
 We can call it again to change the flow rate, or stop it by passing a `0` flowRate:
 
 ```javascript
-await alice.flow({
+await carol.flow({
   recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
   flowRate: '1000000000000000' // 2592 DAIx per month
 });
 
-await alice.flow({
+await carol.flow({
   recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
   flowRate: '0' 
 });


### PR DESCRIPTION
Adjusted the example at the end of the frontend+nodejs.md tutorial. Carol, not Alice since she is the recipient, should be able to change the flowRate. 

## Example Snippet
**🎉 Excellent work, you just started your first Superfluid Flow!** Carol now has a negative **netFlow** which means she is sending tokens out from her wallet. 

We can call it again to change the flow rate, or stop it by passing a `0` flowRate:

Previous example:
```javascript
await alice.flow({
  recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
  flowRate: '1000000000000000' // 2592 DAIx per month
});

await alice.flow({
  recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
  flowRate: '0' 
});
```
Proposed:

```javascript
await carol.flow({
  recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
  flowRate: '1000000000000000' // 2592 DAIx per month
});

await carol.flow({
  recipient: '0xA8f3447922d786045CB582B0C825723B744a54df',
  flowRate: '0' 
});
```